### PR TITLE
updated target links to disallow phishing attacks via _blank: https:/…

### DIFF
--- a/resources/views/website/builder.blade.php
+++ b/resources/views/website/builder.blade.php
@@ -25,7 +25,7 @@
                         @foreach(['armv6', 'armv7', 'i686', 'x86_64'] as $index => $arch)
                             <td class="build-status package-status {{ strtolower($build[$arch]) }}">
                                 @if($build[$arch] != 'Skip' && !is_null($build[$arch . '_log']))
-                                    <a href="https://logs.archstrike.org/{{ preg_replace('/\.gz$/', '', $build[$arch . '_log']) }}" target="_blank">
+                                    <a href="https://logs.archstrike.org/{{ preg_replace('/\.gz$/', '', $build[$arch . '_log']) }}" target="_blank" rel="noopener noreferrer">
                                         <span class="label">{{ $arch }}: </span>
                                         <span class="status {{ $arch }}-sort">{{ $build[$arch] }}</span>
                                         <span class="version">{{ preg_replace([ '/-[^-]*\.log\.html\.gz/', '/' . $build['package'] . '-/' ], [ '', '' ], $build[$arch . '_log']) }}</span>

--- a/resources/views/website/home.blade.php
+++ b/resources/views/website/home.blade.php
@@ -7,7 +7,7 @@
         <div class="intro-column">
             <img src="/img/archstrike.svg" class="img-responsive home-logo" />
             <div class="intro">
-                A security layer for <a href="https://www.archlinux.org" target="_blank">Arch Linux</a> done the <a href="https://wiki.archlinux.org/index.php/Arch_Linux#Principles" target="_blank">Arch Way</a><br />
+                A security layer for <a href="https://www.archlinux.org" target="_blank" rel="noopener noreferrer">Arch Linux</a> done the <a href="https://wiki.archlinux.org/index.php/Arch_Linux#Principles" target="_blank" rel="noopener noreferrer">Arch Way</a><br />
                 and optimized for i686, x86_64, ARMv6, and ARMv7
             </div>
         </div>
@@ -15,11 +15,11 @@
 
     <div class="feed-column">
         <div class="tweet-box">
-            <div class="tweet-box-heading"><a href="https://twitter.com/ArchStrike" target="_blank">Twitter Feed</a></div>
+            <div class="tweet-box-heading"><a href="https://twitter.com/ArchStrike" target="_blank" rel="noopener noreferrer">Twitter Feed</a></div>
             @cache('twitter', 5)
                 @foreach(Twitter::getUserTimeline(['screen_name' => 'ArchStrike', 'count' => 5, 'format' => 'object']) as $tweet)
                     <div class="tweet">
-                        <div><a href="{!! Twitter::linkTweet($tweet) !!}" target="_blank">ArchStrike</a> <span>{{ Twitter::ago($tweet->created_at) }}</span></div>
+                        <div><a href="{!! Twitter::linkTweet($tweet) !!}" target="_blank" rel="noopener noreferrer">ArchStrike</a> <span>{{ Twitter::ago($tweet->created_at) }}</span></div>
                         {!! Twitter::linkify($tweet->text) !!}
                     </div>
                 @endforeach
@@ -27,8 +27,8 @@
         </div>
 
         <div class="contact">
-            <a href="https://github.com/ArchStrike" title="ArchStrike Github" target="_blank"><img src="/img/gh-logo.png" /></a>
-            <a href="https://twitter.com/ArchStrike" title="ArchStrike Twitter" target="_blank"><img src="/img/tw-logo.png" /></a>
+            <a href="https://github.com/ArchStrike" title="ArchStrike Github" target="_blank" rel="noopener noreferrer"><img src="/img/gh-logo.png" /></a>
+            <a href="https://twitter.com/ArchStrike" title="ArchStrike Twitter" target="_blank" rel="noopener noreferrer"><img src="/img/tw-logo.png" /></a>
             <a href="mailto:team@archstrike.org" title="ArchStrike Email"><img src="/img/em-logo.png" /></a>
         </div>
 

--- a/resources/views/website/packages.blade.php
+++ b/resources/views/website/packages.blade.php
@@ -127,8 +127,8 @@
                         <tr>
                             <th>Sources:</th>
                             <td>
-                                <a href="https://github.com/ArchStrike/ArchStrike/blob/master/{{ $package->repo }}/{{ $package->package }}" target="_blank">Package Files</a> /
-                                <a href="https://github.com/ArchStrike/ArchStrike/blob/master/{{ $package->repo }}/{{ $package->package }}/PKGBUILD" target="_blank">PKGBUILD</a>
+                                <a href="https://github.com/ArchStrike/ArchStrike/blob/master/{{ $package->repo }}/{{ $package->package }}" target="_blank" rel="noopener noreferrer">Package Files</a> /
+                                <a href="https://github.com/ArchStrike/ArchStrike/blob/master/{{ $package->repo }}/{{ $package->package }}/PKGBUILD" target="_blank" rel="noopener noreferrer">PKGBUILD</a>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
https://mathiasbynens.github.io/rel-noopener/, fixes issues with target=_blank and disallows the potential for users to drop a link into to point to a malicious site.